### PR TITLE
Add Skyrim 1.7.99 and Address Library format 5 support

### DIFF
--- a/MiscUtil.cpp
+++ b/MiscUtil.cpp
@@ -85,7 +85,7 @@ namespace MiscUtil {
 		if (ptr != 0) SafeWrite8(ptr + 0x118, (enabled ? 1 : 0));
 	}*/
 	void SetMenus(StaticFunctionTag* base, bool enabled){
-		MenuManager::GetSingleton()->showMenus = enabled;
+		MenuManager::GetSingleton()->ShowMenus(enabled);
 	}
 
 	BSFixedString GetRaceEditorID(StaticFunctionTag* base, TESRace* RaceRef) {

--- a/Plugin.h
+++ b/Plugin.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PAPYRUSUTIL_VERSION 45
+#define PAPYRUSUTIL_VERSION 46
 
 #include "skse64/PluginAPI.h"
 #include "skse64/GameAPI.h"

--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,7 @@ extern "C" {
 
 		0,
 		SKSEPluginVersionData::kVersionIndependent_StructsPost629,
-		{ RUNTIME_VERSION_1_6_1130, 0 },
+		{ MAKE_EXE_VERSION(1, 7, 99), 0 },
 
 		0,	// works with any version of the script extender. you probably do not need to put anything here
 	};

--- a/versionlibdb.h
+++ b/versionlibdb.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <vector>
 #include <fstream>
 #include <stdio.h>
 #include <Windows.h>
@@ -16,6 +17,7 @@ public:
 private:
 	std::map<unsigned long long, unsigned long long> _data;
 	std::map<unsigned long long, unsigned long long> _rdata;
+	std::vector<unsigned int> _denseData;
 	int _ver[4];
 	std::string _verStr;
 	std::string _moduleName;
@@ -69,6 +71,15 @@ public:
 
 	bool FindOffsetById(unsigned long long id, unsigned long long& result) const
 	{
+		if (!_denseData.empty())
+		{
+			if (id >= _denseData.size() || _denseData[(size_t)id] == 0)
+				return false;
+
+			result = _denseData[(size_t)id];
+			return true;
+		}
+
 		auto itr = _data.find(id);
 		if (itr != _data.end())
 		{
@@ -90,6 +101,19 @@ public:
 
 	bool FindIdByOffset(unsigned long long offset, unsigned long long& result) const
 	{
+		if (!_denseData.empty())
+		{
+			for (size_t id = 0; id < _denseData.size(); ++id)
+			{
+				if (_denseData[id] == offset)
+				{
+					result = id;
+					return true;
+				}
+			}
+			return false;
+		}
+
 		auto itr = _rdata.find(offset);
 		if (itr == _rdata.end())
 			return false;
@@ -159,6 +183,7 @@ public:
 	{
 		_data.clear();
 		_rdata.clear();
+		_denseData.clear();
 		for (int i = 0; i < 4; i++) _ver[i] = 0;
 		_moduleName = std::string();
 		_base = 0;
@@ -186,6 +211,45 @@ public:
 			return false;
 
 		int format = read<int>(file);
+
+		if (format == 5)
+		{
+			for (int i = 0; i < 4; i++)
+				_ver[i] = (int)read<unsigned int>(file);
+
+			{
+				char moduleName[64] = {};
+				file.read(moduleName, sizeof(moduleName));
+				_moduleName.assign(moduleName, strnlen_s(moduleName, sizeof(moduleName)));
+			}
+
+			const int ptrSize = read<int>(file);
+			const int dataFormat = read<int>(file);
+			const int offsetCount = read<int>(file);
+			if (!file.good() || ptrSize != sizeof(void*) || dataFormat != 0 || offsetCount <= 0 || offsetCount > 0x1000000)
+			{
+				Clear();
+				return false;
+			}
+
+			_denseData.resize((size_t)offsetCount);
+			file.read(reinterpret_cast<char*>(_denseData.data()), (std::streamsize)(_denseData.size() * sizeof(unsigned int)));
+			if (!file.good())
+			{
+				Clear();
+				return false;
+			}
+
+			{
+				char verName[64];
+				_snprintf_s(verName, 64, "%d.%d.%d.%d", _ver[0], _ver[1], _ver[2], _ver[3]);
+				_verStr = verName;
+			}
+
+			HMODULE handle = GetModuleHandleA(_moduleName.empty() ? NULL : _moduleName.c_str());
+			_base = (unsigned long long)handle;
+			return true;
+		}
 
 		if (format != 2)
 			return false;


### PR DESCRIPTION
## Summary
- add support for the dense Address Library format 5 database used by Skyrim 1.7.99
- declare compatibility with Skyrim 1.7.99 and bump `PAPYRUSUTIL_VERSION` to 46
- use the public `MenuManager::ShowMenus()` method required by SKSE 2.3.0

No Papyrus functions or mod features were changed.

## Validation
- built successfully as x64 Release against SKSE 2.3.0
- parsed `versionlib-1-7-99-0.bin` and verified the six relocation IDs used by PapyrusUtil
- confirmed the expected `SKSEPlugin_Load` and `SKSEPlugin_Version` exports

A compiled DLL is available for review. Rebuilt DLL SHA-256: `28CE782E3B5EF05A6D10741B32D10998723F44210DF2415EA410D947A0E54CF3`.